### PR TITLE
Forward port of browser support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
-import zlibLoader from '../build/zlib.mjs';
-
 export const initialize = async () => {
-  const Module = await zlibLoader();
-  Module.map = {};
+  const createModule = await import('../build/zlib.mjs');
+  const Module = await createModule.default({map: {}});
 
   const COMPRESSION_LEVEL = 6;
   const NO_ZLIB_HEADER = -1;
@@ -40,7 +38,7 @@ export const initialize = async () => {
     }
 
     getBuffer() {
-      return Buffer.from(this.buff.buffer, 0, this.offset);
+      return this.buff.slice(0, this.offset);
     }
   }
 
@@ -74,7 +72,7 @@ export const initialize = async () => {
     }
 
     getBuffer() {
-      return Buffer.from(this.buff.buffer, 0, this.offset);
+      return this.buff.slice(0, this.offset);
     }
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -12,15 +12,15 @@ await test("inflate", async t => {
   for (let i = 0; i < 10; i++) {
     source = crypto.randomBytes(1);
     deflated = zlib.deflateRawSync(source, {});
-    t.true(myZlib.inflate(deflated).equals(source));
+    t.true(source.equals(myZlib.inflate(deflated)));
 
     source = crypto.randomBytes(1024);
     deflated = zlib.deflateRawSync(source, {});
-    t.true(myZlib.inflate(deflated).equals(source));
+    t.true(source.equals(myZlib.inflate(deflated)));
 
     source = crypto.randomBytes(1024 * 1024);
     deflated = zlib.deflateRawSync(source, {});
-    t.true(myZlib.inflate(deflated).equals(source));
+    t.true(source.equals(myZlib.inflate(deflated)));
   }
 });
 


### PR DESCRIPTION
- Buffer is not available in browsers, use slice method on Uint8Array object to create a copy instead
- node users (i.e. for unit testing) may want to load the module as CommonJS, moving import into async function allows this